### PR TITLE
Remove object and model components, closes #15 and closes #16

### DIFF
--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/ConstraintClassifier.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/ConstraintClassifier.scala
@@ -74,7 +74,7 @@ abstract class ConstraintClassifier[T <: AnyRef, HEAD <: AnyRef](val dm: DataMod
     }
   }
 
-  def getCandidates(head: HEAD): List[T] = {
+  def getCandidates(head: HEAD): Seq[T] = {
 
     if (tType.equals(headType)) {
       head.asInstanceOf[T] :: Nil
@@ -145,7 +145,7 @@ abstract class ConstraintClassifier[T <: AnyRef, HEAD <: AnyRef](val dm: DataMod
 
   def cName: String = this.getClass.getName
   // TODO: Pick a better name
-  def lbjClassifier = DataModel.rangedDiscreteAttributeOf[T](Symbol(cName))("*", "*") {
+  def lbjClassifier = dm.rangedDiscreteAttributeOf[T](Symbol(cName))("*", "*") {
     x: T => buildWithConstrain(subjectTo.createInferenceCondition[T](this.dm).convertToType[T], onClassifier)(x)
   }
 

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/Learnable.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/Learnable.scala
@@ -20,7 +20,7 @@ abstract class Learnable[T <: AnyRef](val datamodel: DataModel)(implicit tag: Cl
 
   def fromData = datamodel.getNodeWithType[T].getTrainingInstances
 
-  def feature: List[Attribute[T]] = datamodel.getFeaturesOf[T]
+  def feature: List[Attribute[T]] = datamodel.getFeaturesOf[T].toList
   def algorithm: String = "SparseNetwork"
   val featureExtractor = new CombinedDiscreteAttribute[T](this.feature)
 

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/attribute/RelationalFeature.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/attribute/RelationalFeature.scala
@@ -25,7 +25,7 @@ class RelationalFeature[HEAD <: AnyRef, CHILD <: AnyRef](
 
     head: HEAD =>
       {
-        val children = dataModel.getFromRelation[HEAD, CHILD](head)
+        val children = dataModel.getFromRelation[HEAD, CHILD](head).toList
         children.map({
           c => fts.map(f => f.mapping(c))
         })
@@ -68,7 +68,7 @@ class RelationalFeature[HEAD <: AnyRef, CHILD <: AnyRef](
 
   override def addToFeatureVector(t: HEAD, fv: FeatureVector): FeatureVector = {
 
-    val children: List[CHILD] = dataModel.getFromRelation[HEAD, CHILD](t)
+    val children: List[CHILD] = dataModel.getFromRelation[HEAD, CHILD](t).toList
 
     //		children foreach print
     children.zipWithIndex.foreach {

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/DataModelTests/modelWithKeys.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/DataModelTests/modelWithKeys.scala
@@ -2,7 +2,6 @@ package edu.illinois.cs.cogcomp.saulexamples.nlp.DataModelTests
 
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation._
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
-import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
 
 import scala.collection.mutable.{ Map => MutableMap }
 
@@ -52,9 +51,5 @@ object modelWithKeys extends DataModel {
   /** Edge Types
     */
   val docTosen = edge[TextAnnotation, Sentence]('dTos)
-
-  val NODES = ~~(document, sentence)
-  val PROPERTIES = List(docFeatureExample, sentenceFeatureExample)
-  val EDGES = docTosen
 
 }

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/DataModelTests/modelWithSensors.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/DataModelTests/modelWithSensors.scala
@@ -1,7 +1,6 @@
 package edu.illinois.cs.cogcomp.saulexamples.nlp.DataModelTests
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation._
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
-import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
 import edu.illinois.cs.cogcomp.saul.datamodel.edge.Edge
 import edu.illinois.cs.cogcomp.saulexamples.data.Document
 
@@ -46,8 +45,5 @@ object modelWithSensors extends DataModel {
   val docTosen = edge[TextAnnotation, Sentence]('dTos)
   val SenToCons = edge[TextAnnotation, Constituent]('tToc)
 
-  val NODES = List(document, sentence)
-  val PROPERTIES = List(docFeatureExample, sentenceFeatureExample)
-  val EDGES: List[Edge[_, _]] = docTosen
 }
 

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/ReadMe.md
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/ReadMe.md
@@ -15,10 +15,8 @@ The spam classifier simply has documents as one type of entity, so only a collec
 
 ```scala
 object spamDataModel extends DataModel{
-  import edu.illinois.cs.cogcomp.lfs.data_model.DataModel._
 
   val docs=node[Document]             //Collection of documents
-  val NODES: List[Entity[_]] = ~~(docs)    // is the entity for this data model
 ```
 
 ##Features  and Properties

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/spamDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/spamDataModel.scala
@@ -1,7 +1,6 @@
 package edu.illinois.cs.cogcomp.saulexamples.nlp.EmailSpam
 
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
-import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
 import edu.illinois.cs.cogcomp.saul.datamodel.attribute.Attribute
 import edu.illinois.cs.cogcomp.saul.datamodel.edge.Edge
 import edu.illinois.cs.cogcomp.saul.datamodel.node.Node
@@ -13,7 +12,6 @@ import scala.collection.mutable.{ Map => MutableMap }
 object spamDataModel extends DataModel {
 
   val docs = node[Document]
-  val NODES: List[Node[_]] = ~~(docs)
 
   val wordFeature = discreteAttributesGeneratorOf[Document]('wordF) {
     x: Document => x.getWords.toList
@@ -35,6 +33,4 @@ object spamDataModel extends DataModel {
     x: Document => x.getLabel
 
   }
-  val PROPERTIES: List[Attribute[_]] = List(wordFeature, bigramFeature)
-  val EDGES: List[Edge[_, _]] = Nil
 }

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EntityMentionRelation/Classifiers.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EntityMentionRelation/Classifiers.scala
@@ -49,7 +49,7 @@ object Classifiers {
 
   }
 
-  val ePipe = DataModel.discreteAttributesGeneratorOf[ConllRelation]('e1pipe) {
+  val ePipe = discreteAttributesGeneratorOf[ConllRelation]('e1pipe) {
     rel =>
       {
         "e1-org: " + orgClassifier.discreteValue(rel.e1) ::

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EntityMentionRelation/Data.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EntityMentionRelation/Data.scala
@@ -13,8 +13,6 @@ import scala.util.Random
 
 object ErDataModelExample extends DataModel {
 
-  import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
-
   /** Entity Definitions
     */
   val citygazet: GazeteerReader = new GazeteerReader("./data/EntityMentionRelation/known_city.lst", "Gaz:City", true)
@@ -46,8 +44,6 @@ object ErDataModelExample extends DataModel {
     )
   )
 
-  val NODES = ~~(tokens, sentences, pairedRelations)
-
   // val RelationToToken = oneToManyRelationOf[ConllRelation,ConllRawToken]('contain)(('sid,'sid))
 
   /** Access method definitions
@@ -58,8 +54,6 @@ object ErDataModelExample extends DataModel {
   val RelationToOrg = edge[ConllRawToken, ConllRelation]('e2id)
   //('sid === 'sid, 'e2id === 'wordid)//TODO check the runtime problem with the new edge implementation
   val tokenContainsInSentence = edge[ConllRawSentence, ConllRawToken]('sid) //('sid === 'sid)//TODO check the runtime problem with the new edge implementation
-
-  val EDGES = List(RelationToPer, RelationToOrg, tokenContainsInSentence) flatten
 
   /** Attributes
     */
@@ -146,8 +140,6 @@ object ErDataModelExample extends DataModel {
       //      println(r.relType)
       r.relType
   }
-
-  val PROPERTIES = List(word, pos, containsInPersonList, relFeature, relPos)
 
   //  this ++
 

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/FeatureExamples/EdisonDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/FeatureExamples/EdisonDataModel.scala
@@ -4,7 +4,6 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation._
 import edu.illinois.cs.cogcomp.core.utilities.ResourceManager
 import edu.illinois.cs.cogcomp.curator.CuratorFactory
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
-import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
 import edu.illinois.cs.cogcomp.saulexamples.data.{ Document, DocumentReader }
 import edu.illinois.cs.cogcomp.saulexamples.nlp.sensors
 
@@ -78,7 +77,6 @@ object EdisonDataModel extends DataModel {
         x.getText
       }
   }
-  val NODES = ~~(document, sentence, Chunk_constituents)
 
   /** Edge Types
     */
@@ -94,9 +92,6 @@ object EdisonDataModel extends DataModel {
   // val ConstToConst=edge[Constituent,Constituent]('cRc)(PID===PID) //TODO set connections
 
   // val DocTosen=edge[TextAnnotation,Sentence](util.f: TextAnnotation => List[Sentence])('dTos2)// oneToMany
-
-  val PROPERTIES = List(Eview, Rveiw)
-  val EDGES = DocTosen
 }
 
 /** We populate the data and use features in the application below. */

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/setcover/SetCoverSolver.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/setcover/SetCoverSolver.scala
@@ -2,7 +2,6 @@ package edu.illinois.cs.cogcomp.saulexamples.setcover
 import edu.illinois.cs.cogcomp.saul.classifier.ConstraintClassifier
 import edu.illinois.cs.cogcomp.saul.constraint.ConstraintTypeConversion._
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
-import edu.illinois.cs.cogcomp.saul.datamodel.DataModel._
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ Map => MutableMap }
@@ -26,9 +25,6 @@ class SetCoverSolverDataModel extends DataModel {
   )
 
   val cityContainsNeighborhoods = edge[City, Neighborhood]('cityID)
-  val NODES = ~~(cities, neighborhoods)
-  val EDGES = cityContainsNeighborhoods
-  val PROPERTIES = Nil
 }
 
 object ContainsStationConstraint extends ConstraintClassifier[Neighborhood, City](Data.trainingData, new ContainsStation()) {


### PR DESCRIPTION
remove DataModel object, move to trait, and get rid of NODES, PROPERTIES, and EDGES from user code.

Had to use `Seq[Node[_]]` instead of `List[Node[_]]` which is preferable since it supports a larger set of implementations.
