### PR TITLE
Support for symmetric edges

### DIFF
--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
@@ -4,7 +4,7 @@ import edu.illinois.cs.cogcomp.saul.datamodel.property.features.discrete._
 import edu.illinois.cs.cogcomp.saul.datamodel.property.features.real._
 import edu.illinois.cs.cogcomp.saul.datamodel.property.{ EvaluatedProperty, Property }
 import edu.illinois.cs.cogcomp.saul.datamodel.node.{ JoinNode, Node }
-import edu.illinois.cs.cogcomp.saul.datamodel.edge.{SymmetricEdge, AsymmetricEdge, Edge, Link}
+import edu.illinois.cs.cogcomp.saul.datamodel.edge.{ SymmetricEdge, AsymmetricEdge, Edge, Link }
 
 import scala.collection.mutable.{ ListBuffer, Map => MutableMap }
 import scala.reflect.ClassTag

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/edge/Link.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/edge/Link.scala
@@ -19,7 +19,7 @@ class Link[A <: AnyRef, B <: AnyRef](val from: Node[A], val to: Node[B], val nam
 
 trait Edge[T <: AnyRef, U <: AnyRef] {
   def forward: Link[T, U]
-  def backward: Link[U, T],
+  def backward: Link[U, T]
   def matchers: ArrayBuffer[(T, U) => Boolean]
 
   def from = forward.from
@@ -94,7 +94,7 @@ trait Edge[T <: AnyRef, U <: AnyRef] {
 case class AsymmetricEdge[T <: AnyRef, U <: AnyRef](val forward: Link[T, U], val backward: Link[U, T],
                                       ms: Seq[(T, U) => Boolean] = Seq.empty[(T, U) => Boolean])
   extends Edge[T,U] {
-  def matchers = {
+  val matchers = {
     val m = ArrayBuffer.empty[(T, U) => Boolean]
     m ++= ms
     m
@@ -108,7 +108,7 @@ case class SymmetricEdge[T <: AnyRef](link: Link[T, T],
   extends Edge[T,T] {
   def forward = link
   def backward = link
-  def matchers = {
+  val matchers = {
     val m = ArrayBuffer.empty[(T, T) => Boolean]
     m ++= ms
     m


### PR DESCRIPTION
A symmetric edge is one where every `(i,j)` is also automatically `(j,i)`, i.e. it is two-way and thus can only be created between nodes of the same type. Examples of such edges are `Friends`.

Is there a different name for this? Reflective?

Anyway, you create normal edges using `edge` and symmetric edges using `symmEdge`.
