### PR TITLE
script for publishing to our m2 repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val commonSettings = Seq(
     "com.gurobi" % "gurobi" % "6.0",
     "org.apache.commons" % "commons-math3" % "3.0",
     "org.scalatest" % "scalatest_2.11" % "2.2.4"
-  )
+  ),
+  publishTo := Some(Resolver.sftp("CogcompSoftwareRepo", "bilbo.cs.illinois.edu", "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/"))
 )
 
 lazy val saulCore = (project in file("saul-core")).


### PR DESCRIPTION
Adds a line for convenient publishing to our m2 repo.
The command for publishing is `publish`, in the sbt environment. 
