### PR TITLE
warn instead of throw exception closes #219

### DIFF
--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/ConstrainedClassifier.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/classifier/ConstrainedClassifier.scala
@@ -82,7 +82,9 @@ abstract class ConstrainedClassifier[T <: AnyRef, HEAD <: AnyRef](val dm: DataMo
       }
 
       if (l.isEmpty) {
-        throw new Exception("Failed to find part")
+        if (log)
+          println("Failed to find part")
+        l.toSeq
       } else {
         l.filter(filter(_, head)).toSeq
       }


### PR DESCRIPTION
this is a small fix for the time the inference head does not have parts.
