### PR TITLE
read deploy credentials from disk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ scalaVersion in ThisBuild := "2.11.7"
 
 val cogcompNLPVersion = "3.0.64"
 val cogcompPipelineVersion = "0.1.25"
-
-lazy val headerMsg =  """/** This software is released under the University of Illinois/Research and Academic Use License. See
+val ccgGroupId = "edu.illinois.cs.cogcomp"
+val headerMsg =  """/** This software is released under the University of Illinois/Research and Academic Use License. See
                         |  * the LICENSE file in the root folder for details. Copyright (c) 2016
                         |  *
                         |  * Developed by: The Cognitive Computations Group, University of Illinois at Urbana-Champaign
@@ -18,7 +18,7 @@ lazy val root = (project in file(".")).
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val commonSettings = Seq(
-  organization := "edu.illinois.cs.cogcomp",
+  organization := ccgGroupId,
   name := "saul-project",
   version := "0.5",
   resolvers ++= Seq(
@@ -27,16 +27,20 @@ lazy val commonSettings = Seq(
   ),
   javaOptions ++= List("-Xmx11g"),
   libraryDependencies ++= Seq(
-    "edu.illinois.cs.cogcomp" % "LBJava" % "1.2.20" withSources,
-    "edu.illinois.cs.cogcomp" % "illinois-core-utilities" % cogcompNLPVersion withSources,
+    ccgGroupId % "LBJava" % "1.2.20" withSources,
+    ccgGroupId % "illinois-core-utilities" % cogcompNLPVersion withSources,
     "com.gurobi" % "gurobi" % "6.0",
     "org.apache.commons" % "commons-math3" % "3.0",
     "org.scalatest" % "scalatest_2.11" % "2.2.4",
     "ch.qos.logback" % "logback-classic" % "1.1.7"
   ),
   fork := true,
-  publishTo := Some(Resolver.sftp("CogcompSoftwareRepo", "bilbo.cs.illinois.edu", "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/")),
-  credentials += Credentials(Path.userHome / ".sbt" / ".cogcompCredentials"),
+  publishTo := Some(
+    Resolver.ssh(
+      "CogcompSoftwareRepo", "bilbo.cs.illinois.edu",
+      "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/").
+      as ("khashab2", new java.io.File(Path.userHome.absolutePath + "/.ssh/key"))
+  ),
   isSnapshot := true,
   headers := Map(
     "scala" -> (HeaderPattern.cStyleBlockComment, headerMsg),
@@ -58,13 +62,13 @@ lazy val saulExamples = (project in file("saul-examples")).
   settings(
     name := "saul-examples",
     libraryDependencies ++= Seq(
-      "edu.illinois.cs.cogcomp" % "illinois-nlp-pipeline" % cogcompPipelineVersion withSources,
-      "edu.illinois.cs.cogcomp" % "illinois-curator" % cogcompNLPVersion,
-      "edu.illinois.cs.cogcomp" % "illinois-edison" % cogcompNLPVersion,
-      "edu.illinois.cs.cogcomp" % "illinois-corpusreaders" % cogcompNLPVersion,
-      "edu.illinois.cs.cogcomp" % "saul-pos-tagger-models" % "1.3",
-      "edu.illinois.cs.cogcomp" % "saul-er-models" % "1.3",
-      "edu.illinois.cs.cogcomp" % "saul-srl-models" % "1.1"
+      ccgGroupId % "illinois-nlp-pipeline" % cogcompPipelineVersion withSources,
+      ccgGroupId % "illinois-curator" % cogcompNLPVersion,
+      ccgGroupId % "illinois-edison" % cogcompNLPVersion,
+      ccgGroupId % "illinois-corpusreaders" % cogcompNLPVersion,
+      ccgGroupId % "saul-pos-tagger-models" % "1.3",
+      ccgGroupId % "saul-er-models" % "1.3",
+      ccgGroupId % "saul-srl-models" % "1.1"
     )
   ).dependsOn(saulCore)
   .aggregate(saulCore)

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,10 @@ lazy val docSettings = Seq(
   scalacOptions in Test ++= Seq("-Yrangepos")
 )
 
+lazy val saulUser = System.getenv("SAUL_USER")
+lazy val user = if(saulUser == null) System.getProperty("user.name") else saulUser
+lazy val keyFile = new java.io.File(Path.userHome.absolutePath + "/.ssh/id_rsa")
+
 lazy val commonSettings = Seq(
   organization := ccgGroupId,
   name := "saul-project",
@@ -44,8 +48,7 @@ lazy val commonSettings = Seq(
   publishTo := Some(
     Resolver.ssh(
       "CogcompSoftwareRepo", "bilbo.cs.illinois.edu",
-      "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/").
-      as (System.getenv("SAUL_USER"), new java.io.File(Path.userHome.absolutePath + "/.ssh/id_rsa"))
+      "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/") as (user, keyFile)
   ),
   isSnapshot := true,
   headers := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val commonSettings = Seq(
     Resolver.ssh(
       "CogcompSoftwareRepo", "bilbo.cs.illinois.edu",
       "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/").
-      as ("khashab2", new java.io.File(Path.userHome.absolutePath + "/.ssh/key"))
+      as (System.getenv("SAUL_USER"), new java.io.File(Path.userHome.absolutePath + "/.ssh/id_rsa"))
   ),
   isSnapshot := true,
   headers := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).
 lazy val commonSettings = Seq(
   organization := "edu.illinois.cs.cogcomp",
   name := "saul-project",
-  version := "0.4",
+  version := "0.5",
   resolvers ++= Seq(
     Resolver.mavenLocal,
     "CogcompSoftware" at "http://cogcomp.cs.illinois.edu/m2repo/"
@@ -36,6 +36,7 @@ lazy val commonSettings = Seq(
   ),
   fork := true,
   publishTo := Some(Resolver.sftp("CogcompSoftwareRepo", "bilbo.cs.illinois.edu", "/mounts/bilbo/disks/0/www/cogcomp/html/m2repo/")),
+  credentials += Credentials(Path.userHome / ".sbt" / ".cogcompCredentials"),
   isSnapshot := true,
   headers := Map(
     "scala" -> (HeaderPattern.cStyleBlockComment, headerMsg),

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,12 @@ lazy val root = (project in file(".")).
   aggregate(saulCore, saulExamples)
   .enablePlugins(AutomateHeaderPlugin)
 
+lazy val docSettings = Seq(
+  autoAPIMappings := true,
+  apiURL := Some(url("http://cogcomp.cs.illinois.edu/software/doc/saul/")),
+  scalacOptions in Test ++= Seq("-Yrangepos")
+)
+
 lazy val commonSettings = Seq(
   organization := ccgGroupId,
   name := "saul-project",
@@ -50,6 +56,7 @@ lazy val commonSettings = Seq(
 
 lazy val saulCore = (project in file("saul-core")).
   settings(commonSettings: _*).
+  settings(docSettings: _*).
   settings(
     name := "saul",
     libraryDependencies ++= Seq(

--- a/saul-core/README.md
+++ b/saul-core/README.md
@@ -22,6 +22,7 @@ Visit each link for its content
  4. [Model configurations](doc/Models.md)
  5. [Saul library](doc/LBJLIBRARY.md)
 
+The api docs are included [here](http://cogcomp.cs.illinois.edu/software/doc/saul/). 
 
 ## Credits 
 This project has been started by [Parisa Kordjamshidi](mailto:kordjam@illinois.edu) and the development has been done in collaboration with [Hao Wu](mailto:haowu4@illinois.edu), [Sameer Singh](mailto:sameer@cs.washington.edu), [Daniel Khashabi](mailto:khashab2@illinois.edu), [Christos Christodoulopoulos](mailto:christod@illinois.edu). 

--- a/scaladoc.sh
+++ b/scaladoc.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+sbt doc
+
+scp -r saul-core/target/scala-2.11/api/*  khashab2@bilbo.cs.illinois.edu:/mounts/bilbo/disks/0/www/cogcomp/html/software/doc/saul
+
+# in case of having permission issues, try:
+#
+# >  chmod -R 775 *
+# >  chgrp -R cs_danr *


### PR DESCRIPTION
- Now if the key is available inside `~/.ssh/` it never prompts the graphical username-pass window.   Hence we can use automatic deploys. 
- script to deploy the api-docs. Also a version is here: http://cogcomp.cs.illinois.edu/software/doc/saul/  --> Closes #269 