### PR TITLE
Logback.xml should be honored by the Logger.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ lazy val commonSettings = Seq(
   headers := Map(
     "scala" -> (HeaderPattern.cStyleBlockComment, headerMsg),
     "java" -> (HeaderPattern.cStyleBlockComment, headerMsg)
-  )
+  ),
+  excludeDependencies += "org.slf4j" % "slf4j-log4j12"
 ) ++ publishSettings
 
 lazy val root = (project in file("."))

--- a/saul-core/src/main/resources/logback.xml
+++ b/saul-core/src/main/resources/logback.xml
@@ -11,10 +11,9 @@
 <configuration>
     <!-- Appender to a file named based on the application name. -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/${logback.appname}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>logs/${logback.appname}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>../logs/saul.%d{yyyy-MM-dd}.log</fileNamePattern>
 
             <!-- keep 30 days' worth of history -->
             <maxHistory>30</maxHistory>

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/SpamApp.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/EmailSpam/SpamApp.scala
@@ -14,8 +14,8 @@ import scala.collection.JavaConversions._
 
 object SpamApp extends Logging {
 
-  val trainData = new DocumentReader("data/EmailSpam/train").docs.toList
-  val testData = new DocumentReader("data/EmailSpam/test").docs.toList
+  val trainData = new DocumentReader("../data/EmailSpam/train").docs.toList
+  val testData = new DocumentReader("../data/EmailSpam/test").docs.toList
 
   object SpamExperimentType extends Enumeration {
     val TrainAndTest, CacheGraph, TestUsingGraphCache, TestSerialization = Value


### PR DESCRIPTION
- log4j12 based logged was found in classpath due to a transitive
  dependency and that was causing logback-based logger to not work.