### PR TITLE
Fixes bug in JoinNode populate when using `addFromModel` to populate DataModel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ install:
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
   - cmd: SET JAVA_TOOL_OPTIONS=-Dfile.encoding="UTF-8"
 platform:
-  - x86
   - x64
 build_script:
   - sbt formatCheckStrict test:formatCheckStrict it:formatCheckStrict compile
@@ -18,6 +17,4 @@ build_script:
 test_script:
   - sbt "test-only -- -l edu.illinois.cs.cogcomp.saulexamples.HighMemoryTest"
 cache:
-  - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - '%USERPROFILE%\.ivy2\cache -> build.sbt'

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,8 @@ lazy val saulExamples = (project in file("saul-examples")).
       "org.json" % "json" % "20140107",
       "com.twitter" % "hbc-core" % "2.2.0",
       "org.rogach" %% "scallop" % "2.0.5"
-    )
+    ),
+    excludeDependencies += ccgGroupId % "illinois-srl-models"
   ).dependsOn(saulCore)
   .aggregate(saulCore)
   .enablePlugins(AutomateHeaderPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -106,8 +106,7 @@ lazy val saulExamples = (project in file("saul-examples")).
       "org.json" % "json" % "20140107",
       "com.twitter" % "hbc-core" % "2.2.0",
       "org.rogach" %% "scallop" % "2.0.5"
-    ),
-    excludeDependencies += ccgGroupId % "illinois-srl-models"
+    )
   ).dependsOn(saulCore)
   .aggregate(saulCore)
   .enablePlugins(AutomateHeaderPlugin)

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
@@ -132,7 +132,10 @@ trait DataModel extends Logging {
   def join[A <: AnyRef, B <: AnyRef](a: Node[A], b: Node[B])(matcher: (A, B) => Boolean)(implicit tag: ClassTag[(A, B)]): Node[(A, B)] = {
     val n = new JoinNode(a, b, matcher, tag)
     a.joinNodes += n
-    b.joinNodes += n
+
+    if (b != a) {
+      b.joinNodes += n
+    }
     nodes += n
     n
   }

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
@@ -133,6 +133,7 @@ trait DataModel extends Logging {
     val n = new JoinNode(a, b, matcher, tag)
     a.joinNodes += n
 
+    // If nodes `a` and `b` are the same Node type, do not double-count join nodes.
     if (b != a) {
       b.joinNodes += n
     }

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/JoinNode.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/JoinNode.scala
@@ -34,12 +34,12 @@ class JoinNode[A <: AnyRef, B <: AnyRef](val na: Node[A], val nb: Node[B], match
     }
   }
 
-  override def addInstance(t: (A, B), train: Boolean, populateEdge: Boolean = true): Unit = {
+  override def addInstance(t: (A, B), train: Boolean, populateEdge: Boolean = true, populateJoinNodes: Boolean = true): Unit = {
     assert(matcher(t._1, t._2))
     if (!contains(t)) {
-      super.addInstance(t, train, populateEdge)
-      na.addInstance(t._1, train, populateEdge)
-      nb.addInstance(t._2, train, populateEdge)
+      super.addInstance(t, train, populateEdge, populateJoinNodes)
+      na.addInstance(t._1, train, populateEdge, populateJoinNodes)
+      nb.addInstance(t._2, train, populateEdge, populateJoinNodes)
     }
   }
 }

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
@@ -102,10 +102,12 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
     * @param populateEdge If populating edges from the current Node.
     * @param populateJoinNodes Boolean indication if join nodes needs to be populated.
     */
-  def addInstance(instance: T,
-                  train: Boolean = true,
-                  populateEdge: Boolean = true,
-                  populateJoinNodes: Boolean = true): Unit = {
+  def addInstance(
+    instance: T,
+    train: Boolean = true,
+    populateEdge: Boolean = true,
+    populateJoinNodes: Boolean = true
+  ): Unit = {
     val nodeInstance = toNT(instance)
 
     if (containsNT(nodeInstance)) {
@@ -136,8 +138,7 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
     }
   }
 
-  /**
-    * Populate current node instances using instances from a different node on the same type.
+  /** Populate current node instances using instances from a different node on the same type.
     * Usage Node: Expected usage is to copy nodes from one DataModel to another.
     *
     * @param n Node to populate instances from.
@@ -148,10 +149,12 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
   }
 
   /** Operator for adding a sequence of T into my table. */
-  def populate(ts: Iterable[T],
-               train: Boolean = true,
-               populateEdge: Boolean = true,
-               populateJoinNodes: Boolean = true) : Unit = {
+  def populate(
+    ts: Iterable[T],
+    train: Boolean = true,
+    populateEdge: Boolean = true,
+    populateJoinNodes: Boolean = true
+  ): Unit = {
     ts.foreach(addInstance(_, train, populateEdge, populateJoinNodes))
   }
 

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
@@ -100,8 +100,12 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
     * @param instance Node instance.
     * @param train If the instance is a training instance.
     * @param populateEdge If populating edges from the current Node.
+    * @param populateJoinNodes Boolean indication if join nodes needs to be populated.
     */
-  def addInstance(instance: T, train: Boolean = true, populateEdge: Boolean = true): Unit = {
+  def addInstance(instance: T,
+                  train: Boolean = true,
+                  populateEdge: Boolean = true,
+                  populateJoinNodes: Boolean = true): Unit = {
     val nodeInstance = toNT(instance)
 
     if (containsNT(nodeInstance)) {
@@ -126,19 +130,29 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
         incoming.foreach(_.populateUsingTo(instance, train))
       }
 
-      // TODO: Populating join nodes takes significant amount of time on large graphs. Investigate.
-      joinNodes.foreach(_.addFromChild(this, instance, train, populateEdge))
+      if (populateJoinNodes) {
+        joinNodes.foreach(_.addFromChild(this, instance, train, populateEdge))
+      }
     }
   }
 
-  def populateFrom(n: Node[_]): Unit = {
-    populate(n.getTrainingInstances.map(_.asInstanceOf[T]), train = true, populateEdge = false)
-    populate(n.getTestingInstances.map(_.asInstanceOf[T]), train = false, populateEdge = false)
+  /**
+    * Populate current node instances using instances from a different node on the same type.
+    * Usage Node: Expected usage is to copy nodes from one DataModel to another.
+    *
+    * @param n Node to populate instances from.
+    */
+  def populateFrom(n: Node[_])(implicit tag: ClassTag[instanceType]): Unit = {
+    populate(n.getTrainingInstances.map(_.asInstanceOf[instanceType]), train = true, populateEdge = false, populateJoinNodes = false)
+    populate(n.getTestingInstances.map(_.asInstanceOf[instanceType]), train = false, populateEdge = false, populateJoinNodes = false)
   }
 
   /** Operator for adding a sequence of T into my table. */
-  def populate(ts: Iterable[T], train: Boolean = true, populateEdge: Boolean = true) = {
-    ts.foreach(addInstance(_, train, populateEdge))
+  def populate(ts: Iterable[T],
+               train: Boolean = true,
+               populateEdge: Boolean = true,
+               populateJoinNodes: Boolean = true) : Unit = {
+    ts.foreach(addInstance(_, train, populateEdge, populateJoinNodes))
   }
 
   /** Relational operators */

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/node/Node.scala
@@ -133,6 +133,7 @@ class Node[T <: AnyRef](val keyFunc: T => Any = (x: T) => x, val tag: ClassTag[T
       }
 
       if (populateJoinNodes) {
+        // TODO: Populating join nodes takes significant amount of time on large graphs. Investigate.
         joinNodes.foreach(_.addFromChild(this, instance, train, populateEdge))
       }
     }

--- a/saul-core/src/test/scala/edu/illinois/cs/cogcomp/saul/datamodel/JoinNodeTests.scala
+++ b/saul-core/src/test/scala/edu/illinois/cs/cogcomp/saul/datamodel/JoinNodeTests.scala
@@ -1,0 +1,58 @@
+/** This software is released under the University of Illinois/Research and Academic Use License. See
+  * the LICENSE file in the root folder for details. Copyright (c) 2016
+  *
+  * Developed by: The Cognitive Computations Group, University of Illinois at Urbana-Champaign
+  * http://cogcomp.cs.illinois.edu/
+  */
+package edu.illinois.cs.cogcomp.saul.datamodel
+
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+
+class JoinNodeTests extends FlatSpec with Matchers with BeforeAndAfter {
+
+  private object TestDataModel extends DataModel {
+    val names = node[String]
+    val characters = node[Character]
+
+    val nameToCharacters = edge(names, characters)
+    nameToCharacters.addSensor({ name: String => name.toList.map((c: Char) => Char.box(c.toUpper)) })
+
+    val joinNames = join(names, names)((_: String, _: String) => true) // all-pairs
+    val joinNamesFirstCharMatch = join(names, names)((a: String, b: String) => a.charAt(0) == b.charAt(0))
+
+    val joinNodeWithChar = join(names, characters)((_: String, _:Character) => true) // all-pairs
+    val joinNodeWithCharFirstCharMatch = join(names, characters)((a: String, b: Character) => a.charAt(0) == b)
+
+    // Probably an unreal use-case.
+    val complexJoinNode = join(joinNodeWithCharFirstCharMatch, characters)(
+      { case ((_: String, _: Character), _: Character) => true }) // all-pairs
+  }
+
+  before {
+    TestDataModel.clearInstances()
+  }
+
+  "Populating join nodes" should "work correctly" in {
+    val data = List("Abe", "Adele", "Bach", "Mozart")
+
+    import TestDataModel._
+    names.populate(data)
+
+    val numNames = data.size
+    val numChars = data.flatMap(_.toList.map(_.toUpper)).distinct.size
+
+    names.getAllInstances.size should be (numNames)
+    characters.getAllInstances.size should be (numChars)
+
+    joinNames.getAllInstances.size should be (10) // 4_choose_2 + 4
+
+    joinNamesFirstCharMatch.getAllInstances.size should be (5) // A=2_choose_2 + 2; B=1; M=1
+
+    joinNodeWithChar.getAllInstances.size should be (numNames * numChars) // all-pairs
+
+    joinNodeWithCharFirstCharMatch.getAllInstances.size should be (numNames) // one for each name.
+
+    complexJoinNode.getAllInstances.size should be (numNames * numChars)
+  }
+}

--- a/saul-core/src/test/scala/edu/illinois/cs/cogcomp/saul/datamodel/JoinNodeTests.scala
+++ b/saul-core/src/test/scala/edu/illinois/cs/cogcomp/saul/datamodel/JoinNodeTests.scala
@@ -6,8 +6,7 @@
   */
 package edu.illinois.cs.cogcomp.saul.datamodel
 
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
-
+import org.scalatest.{ BeforeAndAfter, FlatSpec, Matchers }
 
 class JoinNodeTests extends FlatSpec with Matchers with BeforeAndAfter {
 
@@ -21,12 +20,13 @@ class JoinNodeTests extends FlatSpec with Matchers with BeforeAndAfter {
     val joinNames = join(names, names)((_: String, _: String) => true) // all-pairs
     val joinNamesFirstCharMatch = join(names, names)((a: String, b: String) => a.charAt(0) == b.charAt(0))
 
-    val joinNodeWithChar = join(names, characters)((_: String, _:Character) => true) // all-pairs
+    val joinNodeWithChar = join(names, characters)((_: String, _: Character) => true) // all-pairs
     val joinNodeWithCharFirstCharMatch = join(names, characters)((a: String, b: Character) => a.charAt(0) == b)
 
     // Probably an unreal use-case.
     val complexJoinNode = join(joinNodeWithCharFirstCharMatch, characters)(
-      { case ((_: String, _: Character), _: Character) => true }) // all-pairs
+      { case ((_: String, _: Character), _: Character) => true }
+    ) // all-pairs
   }
 
   before {
@@ -42,17 +42,17 @@ class JoinNodeTests extends FlatSpec with Matchers with BeforeAndAfter {
     val numNames = data.size
     val numChars = data.flatMap(_.toList.map(_.toUpper)).distinct.size
 
-    names.getAllInstances.size should be (numNames)
-    characters.getAllInstances.size should be (numChars)
+    names.getAllInstances.size should be(numNames)
+    characters.getAllInstances.size should be(numChars)
 
-    joinNames.getAllInstances.size should be (10) // 4_choose_2 + 4
+    joinNames.getAllInstances.size should be(10) // 4_choose_2 + 4
 
-    joinNamesFirstCharMatch.getAllInstances.size should be (5) // A=2_choose_2 + 2; B=1; M=1
+    joinNamesFirstCharMatch.getAllInstances.size should be(5) // A=2_choose_2 + 2; B=1; M=1
 
-    joinNodeWithChar.getAllInstances.size should be (numNames * numChars) // all-pairs
+    joinNodeWithChar.getAllInstances.size should be(numNames * numChars) // all-pairs
 
-    joinNodeWithCharFirstCharMatch.getAllInstances.size should be (numNames) // one for each name.
+    joinNodeWithCharFirstCharMatch.getAllInstances.size should be(numNames) // one for each name.
 
-    complexJoinNode.getAllInstances.size should be (numNames * numChars)
+    complexJoinNode.getAllInstances.size should be(numNames * numChars)
   }
 }

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/PopulateSRLDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/PopulateSRLDataModel.scala
@@ -93,7 +93,7 @@ object PopulateSRLDataModel extends Logging {
         TRAIN_SECTION_S, TRAIN_SECTION_E)
       trainReader.readData()
       logger.info(s"Annotating ${trainReader.textAnnotations.size} training sentences")
-      val filteredTa = addViewAndFilter(trainReader.textAnnotations.toList)
+      val filteredTa = addViewAndFilter(trainReader.textAnnotations)
       printNumbers(trainReader, "training")
       logger.info("Populating SRLDataModel with training data.")
 

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/PopulateSRLDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/PopulateSRLDataModel.scala
@@ -54,7 +54,7 @@ object PopulateSRLDataModel extends Logging {
       case ViewNames.PARSE_GOLD => new ClauseViewGenerator(parseViewName, "CLAUSES_GOLD")
       case ViewNames.PARSE_STANFORD => ClauseViewGenerator.STANFORD
     }
-    def addViewAndFilter(taAll: List[TextAnnotation]): List[TextAnnotation] = {
+    def addViewAndFilter(taAll: Iterable[TextAnnotation]): Iterable[TextAnnotation] = {
       taAll.map { ta =>
         try {
           annotatorService.addView(ta, ViewNames.LEMMA)
@@ -100,7 +100,6 @@ object PopulateSRLDataModel extends Logging {
       filteredTa.foreach { a =>
         gr = new SRLMultiGraphDataModel(parseViewName, frameManager)
         if (!useGoldPredicate) {
-          gr.sentencesToTokens.addSensor(textAnnotationToTokens _)
           gr.sentences.populate(Seq(a))
           val predicateTrainCandidates = gr.tokens.getTrainingInstances.
             collect { case x: Constituent if gr.posTag(x).startsWith("VB") => x.cloneForNewView(ViewNames.SRL_VERB) }
@@ -111,7 +110,6 @@ object PopulateSRLDataModel extends Logging {
         logger.debug("gold relations for this train:" + gr.relations().size)
         if (!useGoldArgBoundaries) {
           val XuPalmerCandidateArgsTraining = gr.predicates.getTrainingInstances.flatMap(x => xuPalmerCandidate(x, (gr.sentences(x.getTextAnnotation) ~> gr.sentencesToStringTree).head))
-          gr.sentencesToRelations.addSensor(textAnnotationToRelationMatch _)
           gr.relations.populate(XuPalmerCandidateArgsTraining)
         }
         logger.debug("all relations for this test:" + gr.relations().size)
@@ -125,7 +123,7 @@ object PopulateSRLDataModel extends Logging {
     testReader.readData()
 
     logger.info(s"Annotating ${testReader.textAnnotations.size} test sentences")
-    val filteredTest = addViewAndFilter(testReader.textAnnotations.toList)
+    val filteredTest = addViewAndFilter(testReader.textAnnotations)
 
     printNumbers(testReader, "test")
 
@@ -133,7 +131,6 @@ object PopulateSRLDataModel extends Logging {
     filteredTest.foreach { a =>
       gr = new SRLMultiGraphDataModel(parseViewName, frameManager)
       if (!useGoldPredicate) {
-        gr.sentencesToTokens.addSensor(textAnnotationToTokens _)
         gr.sentences.populate(Seq(a), train = false)
         val predicateTestCandidates = gr.tokens.getTestingInstances.
           collect { case x: Constituent if gr.posTag(x).startsWith("VB") => x.cloneForNewView(ViewNames.SRL_VERB) }
@@ -144,7 +141,6 @@ object PopulateSRLDataModel extends Logging {
       logger.debug("gold relations for this test:" + gr.relations().size)
       if (!useGoldArgBoundaries) {
         val XuPalmerCandidateArgsTesting = gr.predicates.getTestingInstances.flatMap(x => xuPalmerCandidate(x, (gr.sentences(x.getTextAnnotation) ~> gr.sentencesToStringTree).head))
-        gr.sentencesToRelations.addSensor(textAnnotationToRelationMatch _)
         gr.relations.populate(XuPalmerCandidateArgsTesting, train = false)
       }
       logger.debug("all relations for this test:" + gr.relations().size)

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/SRLMultiGraphDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/SRLMultiGraphDataModel.scala
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.nlp.corpusreaders.AbstractSRLAnnotationReader
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
 import edu.illinois.cs.cogcomp.saul.datamodel.property.PairwiseConjunction
 import edu.illinois.cs.cogcomp.saulexamples.data.SRLFrameManager
+import edu.illinois.cs.cogcomp.saulexamples.nlp.CommonSensors.textAnnotationToTokens
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLSensors._
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLClassifiers._
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLConstrainedClassifiers._
@@ -33,20 +34,18 @@ class SRLMultiGraphDataModel(parseViewName: String = null, frameManager: SRLFram
 
   val sentences = node[TextAnnotation]((x: TextAnnotation) => x.getCorpusId + ":" + x.getId)
 
-  val trees = node[Tree[Constituent]]
-
   val stringTree = node[Tree[String]]
 
   val tokens = node[Constituent]((x: Constituent) => x.getTextAnnotation.getCorpusId + ":" + x.getTextAnnotation.getId + ":" + x.getSpan)
 
   val pairs = join(relations, relations)(_.getSource.getSentenceId == _.getSource.getSentenceId)
-  val sentencesToTrees = edge(sentences, trees)
   val sentencesToStringTree = edge(sentences, stringTree)
   val sentencesToTokens = edge(sentences, tokens)
   val sentencesToRelations = edge(sentences, relations)
   val relationsToPredicates = edge(relations, predicates)
   val relationsToArguments = edge(relations, arguments)
 
+  sentencesToTokens.addSensor(textAnnotationToTokens _)
   sentencesToRelations.addSensor(textAnnotationToRelation _)
   sentencesToRelations.addSensor(textAnnotationToRelationMatch _)
   relationsToArguments.addSensor(relToArgument _)

--- a/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/SRLMultiGraphDataModel.scala
+++ b/saul-examples/src/main/scala/edu/illinois/cs/cogcomp/saulexamples/nlp/SemanticRoleLabeling/SRLMultiGraphDataModel.scala
@@ -14,7 +14,7 @@ import edu.illinois.cs.cogcomp.nlp.corpusreaders.AbstractSRLAnnotationReader
 import edu.illinois.cs.cogcomp.saul.datamodel.DataModel
 import edu.illinois.cs.cogcomp.saul.datamodel.property.PairwiseConjunction
 import edu.illinois.cs.cogcomp.saulexamples.data.SRLFrameManager
-import edu.illinois.cs.cogcomp.saulexamples.nlp.CommonSensors.textAnnotationToTokens
+import edu.illinois.cs.cogcomp.saulexamples.nlp.CommonSensors
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLSensors._
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLClassifiers._
 import edu.illinois.cs.cogcomp.saulexamples.nlp.SemanticRoleLabeling.SRLConstrainedClassifiers._
@@ -30,22 +30,19 @@ class SRLMultiGraphDataModel(parseViewName: String = null, frameManager: SRLFram
   val relations = node[Relation]((x: Relation) => "S" + x.getSource.getTextAnnotation.getCorpusId + ":" + x.getSource.getTextAnnotation.getId + ":" + x.getSource.getSpan +
     "D" + x.getTarget.getTextAnnotation.getCorpusId + ":" + x.getTarget.getTextAnnotation.getId + ":" + x.getTarget.getSpan)
 
-  //val onTheFlyRelationNode= join(predicates, arguments)
-
   val sentences = node[TextAnnotation]((x: TextAnnotation) => x.getCorpusId + ":" + x.getId)
 
   val stringTree = node[Tree[String]]
 
   val tokens = node[Constituent]((x: Constituent) => x.getTextAnnotation.getCorpusId + ":" + x.getTextAnnotation.getId + ":" + x.getSpan)
 
-  val pairs = join(relations, relations)(_.getSource.getSentenceId == _.getSource.getSentenceId)
   val sentencesToStringTree = edge(sentences, stringTree)
   val sentencesToTokens = edge(sentences, tokens)
   val sentencesToRelations = edge(sentences, relations)
   val relationsToPredicates = edge(relations, predicates)
   val relationsToArguments = edge(relations, arguments)
 
-  sentencesToTokens.addSensor(textAnnotationToTokens _)
+  sentencesToTokens.addSensor(CommonSensors.textAnnotationToTokens _)
   sentencesToRelations.addSensor(textAnnotationToRelation _)
   sentencesToRelations.addSensor(textAnnotationToRelationMatch _)
   relationsToArguments.addSensor(relToArgument _)


### PR DESCRIPTION
When copying instances using the `DataModel.addFromModel` method, JoinNodes were copied and also populated recursively. This lead to a large number of unneeded Join Nodes being created during DataModel instance population.

Fixing this issue and handling it similar to the `populateEdge` parameter in this flow.

Addresses #449 