### PR TITLE
[WIP] Enable in-memory feature caching for properties

### DIFF
--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/DataModel.scala
@@ -160,7 +160,11 @@ trait DataModel extends Logging {
     e
   }
 
-  class PropertyApply[T <: AnyRef] private[DataModel] (val node: Node[T], name: String, cache: Boolean, ordered: Boolean) {
+  class PropertyApply[T <: AnyRef] private[DataModel] (val node: Node[T],
+                                                       name: String,
+                                                       isStatic: Boolean,
+                                                       cache: Boolean,
+                                                       ordered: Boolean) {
     papply =>
 
     // TODO(danielk): make the hashmaps immutable
@@ -174,7 +178,10 @@ trait DataModel extends Logging {
 
     def apply(f: T => Boolean)(implicit tag: ClassTag[T]): BooleanProperty[T] = {
       def cachedF = if (cache) { x: T => getOrUpdate(x, f).asInstanceOf[Boolean] } else f
-      val a = new BooleanProperty[T](name, cachedF) with NodeProperty[T] { override def node: Node[T] = papply.node }
+      val a = new BooleanProperty[T](name, cachedF) with NodeProperty[T] {
+        override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
+      }
       papply.node.properties += a
       properties += a
       a
@@ -186,10 +193,12 @@ trait DataModel extends Logging {
       val a = if (ordered) {
         new RealArrayProperty[T](name, newf) with NodeProperty[T] {
           override def node: Node[T] = papply.node
+          override val isCachingEnabled: Boolean = isStatic
         }
       } else {
         new RealGenProperty[T](name, newf) with NodeProperty[T] {
           override def node: Node[T] = papply.node
+          override val isCachingEnabled: Boolean = isStatic
         }
       }
       papply.node.properties += a
@@ -203,6 +212,7 @@ trait DataModel extends Logging {
       val newf: T => Double = { t => cachedF(t).toDouble }
       val a = new RealProperty[T](name, newf) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -215,6 +225,7 @@ trait DataModel extends Logging {
       def cachedF = if (cache) { x: T => getOrUpdate(x, f).asInstanceOf[List[Double]] } else f
       val a = new RealCollectionProperty[T](name, cachedF, ordered) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -227,6 +238,7 @@ trait DataModel extends Logging {
       def cachedF = if (cache) { x: T => getOrUpdate(x, f).asInstanceOf[Double] } else f
       val a = new RealProperty[T](name, cachedF) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -239,6 +251,7 @@ trait DataModel extends Logging {
       def cachedF = if (cache) { x: T => getOrUpdate(x, f).asInstanceOf[String] } else f
       val a = new DiscreteProperty[T](name, cachedF, None) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -251,6 +264,7 @@ trait DataModel extends Logging {
       def cachedF = if (cache) { x: T => getOrUpdate(x, f).asInstanceOf[List[String]] } else f
       val a = new DiscreteCollectionProperty[T](name, cachedF, !ordered) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -265,6 +279,7 @@ trait DataModel extends Logging {
       val r = range.toList
       val a = new DiscreteProperty[T](name, cachedF, Some(r)) with NodeProperty[T] {
         override def node: Node[T] = papply.node
+        override val isCachingEnabled: Boolean = isStatic
       }
       papply.node.properties += a
       properties += a
@@ -272,8 +287,12 @@ trait DataModel extends Logging {
     }
   }
 
-  def property[T <: AnyRef](node: Node[T], name: String = "prop" + properties.size, cache: Boolean = false, ordered: Boolean = false) =
-    new PropertyApply[T](node, name, cache, ordered)
+  def property[T <: AnyRef](node: Node[T],
+                            name: String = "prop" + properties.size,
+                            isStatic: Boolean = false,
+                            cache: Boolean = false,
+                            ordered: Boolean = false) =
+    new PropertyApply[T](node, name, isStatic = isStatic, cache = cache, ordered = ordered)
 
   /** Methods for caching Data Model */
   var hasDerivedInstances = false

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/CombinedDiscreteProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/CombinedDiscreteProperty.scala
@@ -24,7 +24,7 @@ case class CombinedDiscreteProperty[T <: AnyRef](atts: List[Property[T]])(implic
 
   override def outputType: String = "mixed%"
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val featureVector = new FeatureVector()
     atts.foreach(property => featureVector.addFeatures(property.featureVector(instance)))
     featureVector

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/EvaluatedProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/EvaluatedProperty.scala
@@ -21,7 +21,7 @@ class EvaluatedProperty[T <: AnyRef, U](val property: TypedProperty[T, U], val v
 
   val typedProperties = new BooleanProperty[T](name, this.boolMapping)
 
-  override def featureVector(instance: T): FeatureVector = typedProperties.featureVector(instance)
+  override def featureVectorImpl(instance: T): FeatureVector = typedProperties.featureVector(instance)
 
   override val sensor: (T) => String = { t: T => "" }
 }

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/Property.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/Property.scala
@@ -8,9 +8,10 @@ package edu.illinois.cs.cogcomp.saul.datamodel.property
 
 import java.util
 
-import edu.illinois.cs.cogcomp.lbjava.classify.{ Classifier, FeatureVector }
+import edu.illinois.cs.cogcomp.lbjava.classify.{Classifier, FeatureVector}
 import edu.illinois.cs.cogcomp.saul.datamodel.node.Node
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 /** Base trait for representing attributes that can be defined on a
@@ -30,7 +31,20 @@ trait Property[T] {
 
   def apply(instance: T): S = sensor(instance)
 
-  def featureVector(instance: T): FeatureVector
+  val isCachingEnabled = false
+
+  /** WeakHashMap instance to cache feature vectors */
+  private[Property] lazy val featureVectorCache = new mutable.WeakHashMap[T, FeatureVector]()
+
+  final def featureVector(instance: T): FeatureVector = {
+    if (isCachingEnabled) {
+      featureVectorCache.getOrElseUpdate(instance, featureVectorImpl(instance))
+    } else {
+      featureVectorImpl(instance)
+    }
+  }
+
+  protected def featureVectorImpl(instance: T): FeatureVector
 
   def outputType: String = "discrete"
 

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/PropertyWithWindow.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/PropertyWithWindow.scala
@@ -156,7 +156,7 @@ class PropertyWithWindow[T <: AnyRef](
     s"WindowProperty($before,$after}_Of${this.properties.map(_.name).mkString("|")}})"
   }
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val result: FeatureVector = new FeatureVector()
     hiddenProperties.foreach(property => result.addFeatures(property.featureVector(instance)))
     result

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteArrayProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteArrayProperty.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 
 case class DiscreteArrayProperty[T <: AnyRef](name: String, sensor: T => List[String])(implicit val tag: ClassTag[T]) extends TypedProperty[T, List[String]] {
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
 
     var __result: FeatureVector = null

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteCollectionProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteCollectionProperty.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 
 case class DiscreteCollectionProperty[T <: AnyRef](name: String, sensor: T => List[String], ordered: Boolean)(implicit val tag: ClassTag[T]) extends TypedProperty[T, List[String]] {
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
 
     val featureVector = new FeatureVector

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteGenProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteGenProperty.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 
 class DiscreteGenProperty[T <: AnyRef](val name: String, val sensor: T => List[String])(implicit val tag: ClassTag[T]) extends TypedProperty[T, List[String]] {
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
 
     var __result: FeatureVector = null

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/discrete/DiscreteProperty.scala
@@ -16,7 +16,7 @@ case class DiscreteProperty[T <: AnyRef](name: String, sensor: T => String, rang
 
   override def allowableValues: Array[String] = range.map(_.toArray[String]).getOrElse(Array.empty[String])
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     range match {
       case Some(rangeValue) =>
         val result: String = sensor(instance)

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealArrayProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealArrayProperty.scala
@@ -23,7 +23,7 @@ case class RealArrayProperty[T <: AnyRef](name: String, sensor: T => List[Double
 
   override def outputType: String = "real%"
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
 
     val featureVector = new FeatureVector

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealCollectionProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealCollectionProperty.scala
@@ -15,7 +15,7 @@ case class RealCollectionProperty[T <: AnyRef](name: String, sensor: T => List[D
 
   override def outputType: String = "real%"
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
     val featureVector = new FeatureVector
 

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealGenProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealGenProperty.scala
@@ -17,7 +17,7 @@ case class RealGenProperty[T <: AnyRef](name: String, sensor: T => List[Double])
 
   override def outputType: String = "real%"
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val values = sensor(instance)
 
     val featureVector = new FeatureVector

--- a/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealProperty.scala
+++ b/saul-core/src/main/scala/edu/illinois/cs/cogcomp/saul/datamodel/property/features/real/RealProperty.scala
@@ -15,7 +15,7 @@ case class RealProperty[T <: AnyRef](name: String, sensor: T => Double)(implicit
 
   override def outputType: String = "real"
 
-  override def featureVector(instance: T): FeatureVector = {
+  override def featureVectorImpl(instance: T): FeatureVector = {
     val result: Double = sensor(instance)
     new FeatureVector(new RealPrimitiveStringFeature(containingPackage, name, "", result))
   }


### PR DESCRIPTION
Work Items
- [x] Implements feature caching for static features that do not change between runs.
- [ ] Update documentation
- [ ] Add unit tests
- [ ] Verify/Reason if we need a function to explicitly clear the cache?

Idea: Cache static features that do not change across learning iterations. Improves training speed at the cost of using more memory for caching the features. Tested this on the Chunker app and there is a significant improvements to training time.

- Can be extended further with other caching implementation like MapDB (which supports on-disk caching)

I could not think of any other way to implement this feature. Let me know if this is not the right approach or if this can be done differently. Don't know if we can save it within a `NodeInstance` or any other places. Ideas welcome.

